### PR TITLE
fix: standardize .NET Docker templates and exclude .sln from builds

### DIFF
--- a/samples/hosted-agent/dotnet/agent/.dockerignore
+++ b/samples/hosted-agent/dotnet/agent/.dockerignore
@@ -8,6 +8,7 @@ out/
 .vscode/
 *.user
 *.suo
+*.sln
 *.sln.docstates
 .foundry/
 

--- a/samples/hosted-agent/dotnet/agent/Dockerfile
+++ b/samples/hosted-agent/dotnet/agent/Dockerfile
@@ -2,12 +2,14 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 WORKDIR /src
 
+# Copy project files for dependency resolution
+COPY *.csproj* .
+RUN dotnet restore {{SafeProjectName}}.csproj
+
 # Copy files from the current directory on the host to the working directory in the container
 COPY . .
 
-RUN dotnet restore {{SafeProjectName}}.csproj
-RUN dotnet build -c Release --no-restore
-RUN dotnet publish -c Release --no-build -o /app
+RUN dotnet publish -c Release -o /app -p:AssemblyName=app
 
 # Run the application
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
@@ -17,4 +19,4 @@ WORKDIR /app
 COPY --from=build /app .
 
 EXPOSE 8088
-ENTRYPOINT ["dotnet", "{{SafeProjectName}}.dll"]
+ENTRYPOINT ["dotnet", "app.dll"]

--- a/samples/hosted-agent/dotnet/minimal/.dockerignore
+++ b/samples/hosted-agent/dotnet/minimal/.dockerignore
@@ -7,6 +7,8 @@ obj/
 .vscode/
 *.user
 *.suo
+*.sln
+*.sln.docstates
 .foundry/
 
 # Source control

--- a/samples/hosted-agent/dotnet/workflow/.dockerignore
+++ b/samples/hosted-agent/dotnet/workflow/.dockerignore
@@ -8,6 +8,7 @@ out/
 .vscode/
 *.user
 *.suo
+*.sln
 *.sln.docstates
 .foundry/
 

--- a/samples/hosted-agent/dotnet/workflow/Dockerfile
+++ b/samples/hosted-agent/dotnet/workflow/Dockerfile
@@ -1,5 +1,5 @@
 # Build the application
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 WORKDIR /src
 
 # Copy project files for dependency resolution
@@ -12,7 +12,7 @@ COPY . .
 RUN dotnet publish -c Release -o /app -p:AssemblyName=app
 
 # Run the application
-FROM mcr.microsoft.com/dotnet/aspnet:9.0
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
 WORKDIR /app
 
 # Copy everything needed to run the app from the "build" stage.

--- a/samples/hosted-agent/dotnet/workflow/{{SafeProjectName}}.csproj
+++ b/samples/hosted-agent/dotnet/workflow/{{SafeProjectName}}.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
# Fix .NET hosted agent Docker template issues

## Problem

When users create .NET hosted agent projects using the Microsoft Foundry VS Code extension, the **C# Dev Kit** extension automatically generates a `.sln` file in the project directory. This causes Docker builds to fail with:

```
MSBUILD : error MSB1011: Specify which project or solution file to use because 
this folder contains more than one project or solution file.
```

Additionally, the `agent` and `workflow` templates had inconsistent configurations (different .NET versions, different build strategies, different ENTRYPOINT conventions), which is confusing for users.

## Root Cause

1. **C# Dev Kit** (`ms-dotnettools.csdevkit`) auto-generates `.sln` files when it detects `.csproj` files
2. The `.dockerignore` files did not exclude `*.sln`, so the generated `.sln` was copied into the Docker build context
3. `dotnet publish` (without specifying a project file) found both `.csproj` and `.sln`, causing the MSB1011 ambiguity error

## Changes

### `.dockerignore` — Add `*.sln` exclusion (root cause fix)
- `dotnet/agent/.dockerignore` — Added `*.sln`
- `dotnet/workflow/.dockerignore` — Added `*.sln`
- `dotnet/minimal/.dockerignore` — Added `*.sln` and `*.sln.docstates`

### Dockerfile — Standardize across templates
- **`dotnet/workflow/Dockerfile`**: Upgraded from .NET 9.0 → 10.0-alpine to match `agent`
- **`dotnet/agent/Dockerfile`**: 
  - Added two-stage COPY (csproj first → restore → copy all) for better Docker layer caching
  - Unified to use `-p:AssemblyName=app` + `ENTRYPOINT ["dotnet", "app.dll"]` (consistent with `workflow`)
  - Simplified from 3-step (restore → build → publish) to single `dotnet publish`

### `.csproj` — Version alignment
- `dotnet/workflow/{{SafeProjectName}}.csproj`: `net9.0` → `net10.0`

## After this PR

All three .NET templates (`agent`, `workflow`, `minimal`) now share:
- ✅ `.NET 10.0-alpine` base images (smaller, consistent)
- ✅ Two-stage COPY for Docker layer caching optimization  
- ✅ Unified `AssemblyName=app` / `app.dll` ENTRYPOINT convention
- ✅ `*.sln` excluded in `.dockerignore` to prevent C# Dev Kit interference
