### PR TITLE
fix: add missing required 'resources' field to all hosted agent templates

### DIFF
--- a/samples/hosted-agent/dotnet/agent/agent.yaml
+++ b/samples/hosted-agent/dotnet/agent/agent.yaml
@@ -23,3 +23,6 @@ environment_variables:
     value: ${AZURE_AI_PROJECT_ENDPOINT}
   - name: MODEL_DEPLOYMENT_NAME
     value: ${MODEL_DEPLOYMENT_NAME}
+resources:
+  cpu: ""
+  memory: ""

--- a/samples/hosted-agent/dotnet/workflow/agent.yaml
+++ b/samples/hosted-agent/dotnet/workflow/agent.yaml
@@ -22,3 +22,6 @@ environment_variables:
     value: ${PROJECT_ENDPOINT}
   - name: MODEL_DEPLOYMENT_NAME
     value: ${MODEL_DEPLOYMENT_NAME}
+resources:
+  cpu: ""
+  memory: ""

--- a/samples/hosted-agent/python/agent/agent.yaml
+++ b/samples/hosted-agent/python/agent/agent.yaml
@@ -23,3 +23,6 @@ environment_variables:
     value: ${PROJECT_ENDPOINT}
   - name: MODEL_DEPLOYMENT_NAME
     value: ${MODEL_DEPLOYMENT_NAME}
+resources:
+  cpu: ""
+  memory: ""

--- a/samples/hosted-agent/python/langgraph-agent/agent.yaml
+++ b/samples/hosted-agent/python/langgraph-agent/agent.yaml
@@ -22,3 +22,6 @@ environment_variables:
     value: "${AZURE_AI_PROJECT_ENDPOINT}"
   - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
     value: "${AZURE_AI_MODEL_DEPLOYMENT_NAME}"
+resources:
+  cpu: ""
+  memory: ""

--- a/samples/hosted-agent/python/workflow/agent.yaml
+++ b/samples/hosted-agent/python/workflow/agent.yaml
@@ -22,3 +22,6 @@ environment_variables:
     value: ${PROJECT_ENDPOINT}
   - name: MODEL_DEPLOYMENT_NAME
     value: ${MODEL_DEPLOYMENT_NAME}
+resources:
+  cpu: ""
+  memory: ""


### PR DESCRIPTION
# Fix: Add missing `resources` field to hosted agent templates

## Problem

All hosted agent template `agent.yaml` files are missing the required `resources` property as defined by the [ContainerAgent schema](https://raw.githubusercontent.com/microsoft/AgentSchema/refs/heads/main/schemas/v1.0/ContainerAgent.yaml).

This causes schema validation warnings:

> Missing property "resources". yaml-schema: ContainerAgent.yaml

The `resources` field is listed as **required** in the schema (`required: [kind, protocols, resources]`).

## Changes

Added the `resources` field (with `cpu` and `memory` sub-properties) to all 5 hosted agent template `agent.yaml` files:

- `samples/hosted-agent/python/agent/agent.yaml`
- `samples/hosted-agent/python/langgraph-agent/agent.yaml`
- `samples/hosted-agent/python/workflow/agent.yaml`
- `samples/hosted-agent/dotnet/agent/agent.yaml`
- `samples/hosted-agent/dotnet/workflow/agent.yaml`

## Schema Reference

Per the `ContainerAgent.yaml` schema, `resources` references `ContainerResources.yaml` and includes:

```yaml
resources:
  cpu: ""
  memory: ""
```
