### PR TITLE
feat(catalog): add per-path sample-overrides.json for stable structural fields

### DIFF
--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -465,14 +465,7 @@ function mergeExistingDisplayFields(templates) {
 
 /**
  * Load source-controlled per-path overrides. Returns an empty map when the
- * overrides file is missing or unreadable so generation never fails on it.
- *
- * The overrides file lets us correct individual sample metadata (e.g. setting
- * `framework: "copilot-sdk"` for a sample that lives under `bring-your-own/`
- * in the upstream tree but is conceptually a different framework) without
- * touching upstream or editing the generated catalog by hand. Every field on
- * a template is overridable; structural fields (`language`, `framework`,
- * `protocol`, `requiresModel`) are the typical use case.
+ * file is missing or unreadable so generation never fails on it.
  *
  * @returns {Map<string, Record<string, unknown>>}
  */
@@ -497,10 +490,11 @@ function loadOverrides() {
 }
 
 /**
- * Apply per-path overrides to scanned templates. Override fields win over the
- * values derived from the upstream tree, so the catalog is deterministic
- * across regenerations regardless of LLM output. Unknown override paths are
- * logged but never fail the build (upstream may have moved a sample).
+ * Shallow-merge per-path overrides onto scanned templates. Lets us correct
+ * structural fields (e.g. `framework: "copilot-sdk"` for a sample that lives
+ * under `bring-your-own/` upstream) without touching upstream or hand-editing
+ * the generated catalog. Unknown override paths are logged but never fail
+ * the build — upstream may have moved a sample.
  *
  * @param {Array<{path: string} & Record<string, unknown>>} templates
  * @param {Map<string, Record<string, unknown>>} overrides

--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -28,6 +28,7 @@ const REPO_ROOT = process.env.REPO_ROOT || resolve(__dirname, '..', '..');
 const SAMPLES_REPO_URL = process.env.SAMPLES_REPO_URL || 'https://github.com/microsoft-foundry/foundry-samples/';
 const SAMPLES_REPO_API = 'https://api.github.com/repos/microsoft-foundry/foundry-samples';
 const OUTPUT_PATH = join(REPO_ROOT, 'samples', 'hosted-agent', 'sample-catalog.json');
+const OVERRIDES_PATH = join(REPO_ROOT, 'samples', 'hosted-agent', 'sample-overrides.json');
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN || '';
 
@@ -50,6 +51,7 @@ const DIMENSION_DEFAULTS = {
         options: {
             'agent-framework': 'Agent Framework',
             'bring-your-own': 'Bring Your Own',
+            'copilot-sdk': 'Copilot SDK',
         },
     },
     protocol: {
@@ -462,6 +464,68 @@ function mergeExistingDisplayFields(templates) {
 }
 
 /**
+ * Load source-controlled per-path overrides. Returns an empty map when the
+ * overrides file is missing or unreadable so generation never fails on it.
+ *
+ * The overrides file lets us correct individual sample metadata (e.g. setting
+ * `framework: "copilot-sdk"` for a sample that lives under `bring-your-own/`
+ * in the upstream tree but is conceptually a different framework) without
+ * touching upstream or editing the generated catalog by hand. Every field on
+ * a template is overridable; structural fields (`language`, `framework`,
+ * `protocol`, `requiresModel`) are the typical use case.
+ *
+ * @returns {Map<string, Record<string, unknown>>}
+ */
+function loadOverrides() {
+    /** @type {Map<string, Record<string, unknown>>} */
+    const byPath = new Map();
+    if (!existsSync(OVERRIDES_PATH)) {
+        return byPath;
+    }
+    try {
+        const raw = JSON.parse(readFileSync(OVERRIDES_PATH, 'utf-8'));
+        const entries = (raw && typeof raw === 'object' && raw.byPath) || {};
+        for (const [path, fields] of Object.entries(entries)) {
+            if (fields && typeof fields === 'object') {
+                byPath.set(path, /** @type {Record<string, unknown>} */ (fields));
+            }
+        }
+    } catch (/** @type {any} */ err) {
+        console.warn(`Warning: could not read sample-overrides.json: ${err.message}`);
+    }
+    return byPath;
+}
+
+/**
+ * Apply per-path overrides to scanned templates. Override fields win over the
+ * values derived from the upstream tree, so the catalog is deterministic
+ * across regenerations regardless of LLM output. Unknown override paths are
+ * logged but never fail the build (upstream may have moved a sample).
+ *
+ * @param {Array<{path: string} & Record<string, unknown>>} templates
+ * @param {Map<string, Record<string, unknown>>} overrides
+ */
+function applyOverrides(templates, overrides) {
+    if (overrides.size === 0) {
+        return;
+    }
+    /** @type {Set<string>} */
+    const seenPaths = new Set();
+    for (const template of templates) {
+        seenPaths.add(template.path);
+        const fields = overrides.get(template.path);
+        if (fields) {
+            Object.assign(template, fields);
+        }
+    }
+    for (const path of overrides.keys()) {
+        if (!seenPaths.has(path)) {
+            console.warn(`Warning: override for "${path}" did not match any scanned template; check sample-overrides.json.`);
+        }
+    }
+}
+
+/**
  * Auto-fill empty displayName and description using LLM (with README as context).
  * Falls back to directory-name-based displayName if LLM is unavailable.
  * Only fills fields that are still empty after merging existing values.
@@ -514,7 +578,11 @@ async function main() {
     // Step 1: Preserve existing PM-edited or previously auto-filled values
     mergeExistingDisplayFields(templates);
 
-    // Step 2: Auto-fill remaining empty fields (LLM if configured, else directory name fallback)
+    // Step 2: Apply source-controlled per-path overrides (structural fields like
+    // `framework` that the upstream tree layout cannot express on its own).
+    applyOverrides(templates, loadOverrides());
+
+    // Step 3: Auto-fill remaining empty fields (LLM if configured, else directory name fallback)
     await autoFillDisplayFields(templates, commitSha);
 
     const dimensions = buildDimensions(templates);

--- a/samples/hosted-agent/sample-catalog.json
+++ b/samples/hosted-agent/sample-catalog.json
@@ -1,7 +1,7 @@
 {
     "commitSha": "0ce024a9ebf40f5dffe2b624043dece254a63438",
     "repo": "https://github.com/microsoft-foundry/foundry-samples/",
-    "generatedAt": "2026-05-18T03:16:00Z",
+    "generatedAt": "2026-05-08T08:36:42Z",
     "dimensions": {
         "language": {
             "title": "Select a Language",
@@ -28,10 +28,6 @@
                 {
                     "id": "bring-your-own",
                     "displayName": "Bring Your Own"
-                },
-                {
-                    "id": "copilot-sdk",
-                    "displayName": "Copilot SDK"
                 }
             ]
         },
@@ -129,7 +125,7 @@
         },
         {
             "language": "python",
-            "framework": "copilot-sdk",
+            "framework": "bring-your-own",
             "protocol": "invocations",
             "displayName": "Multi-Turn Chat",
             "description": "Streams Copilot SDK session events with multi-turn conversation support.",

--- a/samples/hosted-agent/sample-catalog.json
+++ b/samples/hosted-agent/sample-catalog.json
@@ -1,7 +1,7 @@
 {
     "commitSha": "0ce024a9ebf40f5dffe2b624043dece254a63438",
     "repo": "https://github.com/microsoft-foundry/foundry-samples/",
-    "generatedAt": "2026-05-08T08:36:42Z",
+    "generatedAt": "2026-05-18T03:16:00Z",
     "dimensions": {
         "language": {
             "title": "Select a Language",
@@ -28,6 +28,10 @@
                 {
                     "id": "bring-your-own",
                     "displayName": "Bring Your Own"
+                },
+                {
+                    "id": "copilot-sdk",
+                    "displayName": "Copilot SDK"
                 }
             ]
         },
@@ -125,7 +129,7 @@
         },
         {
             "language": "python",
-            "framework": "bring-your-own",
+            "framework": "copilot-sdk",
             "protocol": "invocations",
             "displayName": "Multi-Turn Chat",
             "description": "Streams Copilot SDK session events with multi-turn conversation support.",

--- a/samples/hosted-agent/sample-catalog.json
+++ b/samples/hosted-agent/sample-catalog.json
@@ -1,7 +1,7 @@
 {
     "commitSha": "0ce024a9ebf40f5dffe2b624043dece254a63438",
     "repo": "https://github.com/microsoft-foundry/foundry-samples/",
-    "generatedAt": "2026-05-08T08:36:42Z",
+    "generatedAt": "2026-05-18T03:22:31Z",
     "dimensions": {
         "language": {
             "title": "Select a Language",
@@ -28,6 +28,10 @@
                 {
                     "id": "bring-your-own",
                     "displayName": "Bring Your Own"
+                },
+                {
+                    "id": "copilot-sdk",
+                    "displayName": "Copilot SDK"
                 }
             ]
         },
@@ -125,7 +129,7 @@
         },
         {
             "language": "python",
-            "framework": "bring-your-own",
+            "framework": "copilot-sdk",
             "protocol": "invocations",
             "displayName": "Multi-Turn Chat",
             "description": "Streams Copilot SDK session events with multi-turn conversation support.",

--- a/samples/hosted-agent/sample-catalog.json
+++ b/samples/hosted-agent/sample-catalog.json
@@ -1,7 +1,7 @@
 {
     "commitSha": "0ce024a9ebf40f5dffe2b624043dece254a63438",
     "repo": "https://github.com/microsoft-foundry/foundry-samples/",
-    "generatedAt": "2026-05-18T03:22:31Z",
+    "generatedAt": "2026-05-08T08:36:42Z",
     "dimensions": {
         "language": {
             "title": "Select a Language",
@@ -28,10 +28,6 @@
                 {
                     "id": "bring-your-own",
                     "displayName": "Bring Your Own"
-                },
-                {
-                    "id": "copilot-sdk",
-                    "displayName": "Copilot SDK"
                 }
             ]
         },
@@ -129,7 +125,7 @@
         },
         {
             "language": "python",
-            "framework": "copilot-sdk",
+            "framework": "bring-your-own",
             "protocol": "invocations",
             "displayName": "Multi-Turn Chat",
             "description": "Streams Copilot SDK session events with multi-turn conversation support.",

--- a/samples/hosted-agent/sample-overrides.json
+++ b/samples/hosted-agent/sample-overrides.json
@@ -1,6 +1,4 @@
 {
-    "$schema": "./sample-overrides.schema.json",
-    "$comment": "Per-path field overrides applied AFTER scanning foundry-samples and BEFORE LLM auto-fill. Use sparingly; prefer fixing upstream when possible. Keys under 'byPath' are exact paths from sample-catalog.json's templates[].path. Values are partial templates merged on top of the scanned template.",
     "byPath": {
         "samples/python/hosted-agents/bring-your-own/invocations/github-copilot": {
             "framework": "copilot-sdk"

--- a/samples/hosted-agent/sample-overrides.json
+++ b/samples/hosted-agent/sample-overrides.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "./sample-overrides.schema.json",
+    "$comment": "Per-path field overrides applied AFTER scanning foundry-samples and BEFORE LLM auto-fill. Use sparingly; prefer fixing upstream when possible. Keys under 'byPath' are exact paths from sample-catalog.json's templates[].path. Values are partial templates merged on top of the scanned template.",
+    "byPath": {
+        "samples/python/hosted-agents/bring-your-own/invocations/github-copilot": {
+            "framework": "copilot-sdk"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Some hosted-agent samples live in the upstream tree under one framework folder but are conceptually a different framework. The first concrete case: `samples/python/hosted-agents/bring-your-own/invocations/github-copilot` sits under `bring-your-own/` but actually uses the Copilot SDK and should surface as a separate `framework` option in the QuickPick.

Hard-coding such cases in the generator or hand-editing the catalog is not reproducible across `Sync Sample Catalog` runs. This PR introduces a small, source-controlled override map so the catalog is byte-deterministic across regenerations.

## What's in this PR

- **`samples/hosted-agent/sample-overrides.json`** — per-path field overrides. Today it contains one entry; future cases just add a key.
- **`generate_sample_catalog.mjs`** — new `loadOverrides()` + `applyOverrides()` step. Runs *after* scanning the upstream tree and *after* merging previous PM-edited display fields, so override values win over the scanned defaults but never clobber PM-curated `displayName`/`description`.
- **`DIMENSION_DEFAULTS.framework`** — register `copilot-sdk: 'Copilot SDK'` so when a template uses that id, `dimensions.framework.options` renders a friendly label. Dimensions are still derived dynamically from the template list, so unused ids stay omitted.

## What is NOT in this PR

`samples/hosted-agent/sample-catalog.json` is intentionally **not** modified here — it is the *output* of the `Sync Sample Catalog` workflow, not a hand-edited file. After this PR lands, running the workflow once will produce a follow-up auto-PR that applies the override to the catalog. Keeping the two concerns separated avoids hand-edit drift and conflict noise.

## Determinism check

Verified end-to-end on this branch by triggering the `Sync Sample Catalog` workflow against `yimin/sample-catalog-overrides` (run [#26011735386](https://github.com/microsoft/microsoft-foundry-for-vscode/actions/runs/26011735386)). The auto-PR produced exactly the expected three-line structural change plus a `generatedAt` timestamp bump:

```diff
 "framework": {
+  { "id": "copilot-sdk", "displayName": "Copilot SDK" }
 }
 ...
-  "framework": "bring-your-own",
+  "framework": "copilot-sdk",
   "path": "samples/python/hosted-agents/bring-your-own/invocations/github-copilot"
```

## Pipeline order in the generator

```
scanTemplates(commitSha)
   ↓
mergeExistingDisplayFields(templates)        ← retains PM-curated displayName / description
   ↓
applyOverrides(templates, loadOverrides())   ← NEW — structural fields win
   ↓
autoFillDisplayFields(templates, commitSha)  ← LLM fallback only for empty fields
   ↓
buildDimensions(templates)
   ↓
write sample-catalog.json
```

## Failure modes (designed for)

| Scenario | Behaviour |
|---|---|
| Override file deleted | Silent fallback to default; `copilot-sdk` disappears from dimensions next sync |
| Override path no longer exists upstream | Warn in workflow log; sync continues |
| Override sets a field upstream also provides | Override wins (intentional) |
| Override sets `displayName` / `description` | Wins over both scan and LLM (intentional escape hatch) |

## Next step after merge

Run **Sync Sample Catalog** (workflow_dispatch) on `dev` with the desired `commit_sha`. The workflow will open a follow-up draft PR whose only diff is the expected structural change above.
