### PR TITLE
feat(catalog): derive requiresModel from agent.manifest.yaml resources

### DIFF
--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -198,9 +198,9 @@ async function fetchAgentYaml(samplePath, ref) {
 
 /**
  * Minimal parser for agent.manifest.yaml — detects whether the manifest
- * declares a top-level `resources:` list that includes an entry of
- * `kind: model`. Tracks the active top-level key so that `- kind: model`
- * appearing under an unrelated list does not produce a false positive.
+ * declares a top-level `resources:` list containing `kind: model`. Matches
+ * both `- kind: model` and the multi-line continuation form, and limits
+ * scanning to the `resources:` block to avoid false positives.
  * @param {string} content
  * @returns {{ hasModelResource: boolean }}
  */
@@ -213,8 +213,13 @@ function parseAgentManifestYaml(content) {
             inResources = stripped.startsWith('resources:');
             continue;
         }
-        if (inResources && stripped.startsWith('- kind:')) {
-            const value = stripped.substring('- kind:'.length).trim();
+        if (!inResources) {
+            continue;
+        }
+        // Strip optional `- ` so the inline and continuation forms both match.
+        const withoutDash = stripped.replace(/^-\s+/, '');
+        if (withoutDash.startsWith('kind:')) {
+            const value = withoutDash.substring('kind:'.length).trim().replace(/^["']|["']$/g, '');
             if (value === 'model') {
                 return { hasModelResource: true };
             }
@@ -390,10 +395,7 @@ async function scanTemplates(commitSha) {
 
                 for (const templateDir of templateDirs) {
                     const templatePath = `${protocolPath}/${templateDir}`;
-                    const [agentInfo, manifestInfo] = await Promise.all([
-                        fetchAgentYaml(templatePath, commitSha),
-                        fetchAgentManifestYaml(templatePath, commitSha),
-                    ]);
+                    const agentInfo = await fetchAgentYaml(templatePath, commitSha);
 
                     /** @type {'responses' | 'invocations'} */
                     let protocol = /** @type {'responses' | 'invocations'} */ (protocolDir);
@@ -404,9 +406,13 @@ async function scanTemplates(commitSha) {
                             protocol = agentInfo.protocols[0];
                         }
                     }
-                    // Manifest-declared model resources also imply requiresModel.
-                    if (manifestInfo?.hasModelResource) {
-                        requiresModel = true;
+                    // Only consult agent.manifest.yaml when agent.yaml exists
+                    // and reported no model env; other cases already default to `true`.
+                    if (agentInfo && !agentInfo.hasModelEnv) {
+                        const manifestInfo = await fetchAgentManifestYaml(templatePath, commitSha);
+                        if (manifestInfo?.hasModelResource) {
+                            requiresModel = true;
+                        }
                     }
 
                     templates.push({
@@ -424,10 +430,7 @@ async function scanTemplates(commitSha) {
             // Templates directly under framework dir (e.g. csharp/agent-framework/hello-world)
             for (const templateDir of directTemplateDirs) {
                 const templatePath = `${frameworkPath}/${templateDir}`;
-                const [agentInfo, manifestInfo] = await Promise.all([
-                    fetchAgentYaml(templatePath, commitSha),
-                    fetchAgentManifestYaml(templatePath, commitSha),
-                ]);
+                const agentInfo = await fetchAgentYaml(templatePath, commitSha);
 
                 /** @type {'responses' | 'invocations'} */
                 let protocol = 'responses';
@@ -438,9 +441,12 @@ async function scanTemplates(commitSha) {
                         protocol = agentInfo.protocols[0];
                     }
                 }
-                // Manifest-declared model resources also imply requiresModel.
-                if (manifestInfo?.hasModelResource) {
-                    requiresModel = true;
+                // See comment in the protocolDirs loop above.
+                if (agentInfo && !agentInfo.hasModelEnv) {
+                    const manifestInfo = await fetchAgentManifestYaml(templatePath, commitSha);
+                    if (manifestInfo?.hasModelResource) {
+                        requiresModel = true;
+                    }
                 }
 
                 templates.push({

--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -196,6 +196,49 @@ async function fetchAgentYaml(samplePath, ref) {
     }
 }
 
+/**
+ * Minimal parser for agent.manifest.yaml — detects whether the manifest
+ * declares a top-level `resources:` list that includes an entry of
+ * `kind: model`. Tracks the active top-level key so that `- kind: model`
+ * appearing under an unrelated list does not produce a false positive.
+ * @param {string} content
+ * @returns {{ hasModelResource: boolean }}
+ */
+function parseAgentManifestYaml(content) {
+    let inResources = false;
+    for (const rawLine of content.split('\n')) {
+        const stripped = rawLine.trim();
+        // Detect top-level key (column 0, e.g. `resources:`, `metadata:`).
+        if (/^[A-Za-z_][\w-]*:/.test(rawLine)) {
+            inResources = stripped.startsWith('resources:');
+            continue;
+        }
+        if (inResources && stripped.startsWith('- kind:')) {
+            const value = stripped.substring('- kind:'.length).trim();
+            if (value === 'model') {
+                return { hasModelResource: true };
+            }
+        }
+    }
+    return { hasModelResource: false };
+}
+
+/**
+ * Fetch and parse agent.manifest.yaml for a sample directory.
+ * @param {string} samplePath
+ * @param {string} ref
+ * @returns {Promise<{ hasModelResource: boolean } | null>}
+ */
+async function fetchAgentManifestYaml(samplePath, ref) {
+    const rawUrl = `https://raw.githubusercontent.com/microsoft-foundry/foundry-samples/${ref}/${samplePath}/agent.manifest.yaml`;
+    try {
+        const content = await fetchText(rawUrl);
+        return parseAgentManifestYaml(content);
+    } catch {
+        return null;
+    }
+}
+
 // Azure OpenAI configuration (from GitHub Secrets via env vars)
 const AZURE_OPENAI_ENDPOINT = process.env.AZURE_OPENAI_ENDPOINT || '';
 const AZURE_OPENAI_API_KEY = process.env.AZURE_OPENAI_API_KEY || '';
@@ -347,7 +390,10 @@ async function scanTemplates(commitSha) {
 
                 for (const templateDir of templateDirs) {
                     const templatePath = `${protocolPath}/${templateDir}`;
-                    const agentInfo = await fetchAgentYaml(templatePath, commitSha);
+                    const [agentInfo, manifestInfo] = await Promise.all([
+                        fetchAgentYaml(templatePath, commitSha),
+                        fetchAgentManifestYaml(templatePath, commitSha),
+                    ]);
 
                     /** @type {'responses' | 'invocations'} */
                     let protocol = /** @type {'responses' | 'invocations'} */ (protocolDir);
@@ -357,6 +403,10 @@ async function scanTemplates(commitSha) {
                         if (agentInfo.protocols.length > 0) {
                             protocol = agentInfo.protocols[0];
                         }
+                    }
+                    // Manifest-declared model resources also imply requiresModel.
+                    if (manifestInfo?.hasModelResource) {
+                        requiresModel = true;
                     }
 
                     templates.push({
@@ -374,7 +424,10 @@ async function scanTemplates(commitSha) {
             // Templates directly under framework dir (e.g. csharp/agent-framework/hello-world)
             for (const templateDir of directTemplateDirs) {
                 const templatePath = `${frameworkPath}/${templateDir}`;
-                const agentInfo = await fetchAgentYaml(templatePath, commitSha);
+                const [agentInfo, manifestInfo] = await Promise.all([
+                    fetchAgentYaml(templatePath, commitSha),
+                    fetchAgentManifestYaml(templatePath, commitSha),
+                ]);
 
                 /** @type {'responses' | 'invocations'} */
                 let protocol = 'responses';
@@ -384,6 +437,10 @@ async function scanTemplates(commitSha) {
                     if (agentInfo.protocols.length > 0) {
                         protocol = agentInfo.protocols[0];
                     }
+                }
+                // Manifest-declared model resources also imply requiresModel.
+                if (manifestInfo?.hasModelResource) {
+                    requiresModel = true;
                 }
 
                 templates.push({


### PR DESCRIPTION
## Summary

Extend the catalog sync script to also derive `requiresModel` from each sample's `agent.manifest.yaml`, not just `agent.yaml`'s `environment_variables`.

When the manifest declares a top-level `resources:` list with an entry of `kind: model`, the sample is treated as requiring a model deployment.

## Why

Currently `requiresModel` is `true` only when `agent.yaml` lists `AZURE_AI_MODEL_DEPLOYMENT_NAME` under `environment_variables`. Several upstream samples (notably `csharp/hosted-agents/agent-framework/{local-tools, mcp-tools, simple-agent, text-search-rag, workflows}`) declare their model dependency in `agent.manifest.yaml` instead, so they were being incorrectly emitted as `requiresModel: false`.

## What changed

- New `parseAgentManifestYaml(content)` and `fetchAgentManifestYaml(samplePath, ref)` helpers, matching the existing `parseAgentYaml` / `fetchAgentYaml` shape (line-scan, no YAML lib, returns `null` on fetch failure).
- The parser tracks the active top-level key (`/^[A-Za-z_][\w-]*:/`) so that `template.resources` (cpu/memory) cannot trigger a false positive.
- Both `scanTemplates` loops now fetch `agent.yaml` and `agent.manifest.yaml` in parallel with `Promise.all` and OR the manifest signal into `requiresModel`. The merge is monotone: the manifest can only flip `false → true`, never override a positive `agent.yaml` signal.

## Verification

Against the 6 upstream csharp+agent-framework samples that lack `.env.example`:

| Sample | Detected `requiresModel` | Expected |
|---|---|---|
| `local-tools` | `true` | ✅ |
| `mcp-tools` | `true` | ✅ |
| `simple-agent` | `true` | ✅ |
| `text-search-rag` | `true` | ✅ |
| `workflows` | `true` | ✅ |
| `invocations-echo-agent` | `false` | ✅ (manifest `resources: []`, README explicitly says "No LLM ... required") |

## Reviewer checks

- Confirm the manifest parser does not over-match (`template.resources` with cpu/memory should NOT trigger).
- Trigger the `Sync Sample Catalog` workflow (workflow_dispatch with the current SHA) and confirm the resulting PR flips the 5 csharp samples to `requiresModel: true` without other unintended changes.
