### PR TITLE
feat(catalog): nested-sample support, deterministic displayName, and manifest-derived requiresModel

### DIFF
--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -2,11 +2,12 @@
 /**
  * Generate samples/hosted-agent/sample-catalog.json from the foundry-samples repository.
  *
- * Scans the hosted-agents directory tree in microsoft-foundry/foundry-samples,
- * parses each sample's agent.yaml to extract protocol and model requirements,
- * fetches README.md to auto-fill displayName and description (only for empty fields),
- * and writes a flat catalog JSON that the VS Code extension consumes for
- * template selection.
+ * Walks the hosted-agents tree in microsoft-foundry/foundry-samples once via
+ * the git-tree API, parses each sample's agent.yaml (+ optional
+ * agent.manifest.yaml) for protocol and model requirements, derives
+ * displayName from the directory name, and — when AZURE_OPENAI_* secrets are
+ * set — fills the description with a short LLM-generated sentence sourced
+ * from the sample's README.md.
  *
  * Usage:
  *   node generate_sample_catalog.mjs <commitSha>
@@ -15,6 +16,7 @@
  *   GITHUB_TOKEN        Optional GitHub token for API authentication.
  *   REPO_ROOT           Repository root (defaults to two levels up from this script).
  *   SAMPLES_REPO_URL    Source repo URL (defaults to https://github.com/microsoft-foundry/foundry-samples/).
+ *   AZURE_OPENAI_*      Optional; when set, descriptions are LLM-generated.
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, appendFileSync } from 'node:fs';
@@ -237,8 +239,10 @@ function inferProtocolFromPath(templatePath) {
 }
 
 /**
- * Minimal parser for agent.yaml — extracts protocol and environment_variables.
- * Does NOT use eval or dynamic code execution.
+ * Minimal parser for agent.yaml. Extracts the declared protocol(s) and
+ * whether the sample exposes the AZURE_AI_MODEL_DEPLOYMENT_NAME env var
+ * (used as a heuristic for `requiresModel`). Does NOT use eval or a real
+ * YAML library — a regex-y scan is sufficient for our two fields.
  * @param {string} content
  * @returns {{ protocols: Array<'responses' | 'invocations'>, hasModelEnv: boolean }}
  */
@@ -435,12 +439,9 @@ ${readmeContent.substring(0, 2000)}`;
 
 /**
  * Derive a displayName from the template's directory name. Strips a leading
- * numeric ordering prefix (`09-`, `12-`) so reorderings upstream don't bleed
- * into the picker, then converts dash-separated tokens into Title Case words.
- *
- *   `09-declarative-customer-support` -> `Declarative Customer Support`
- *   `hello-world-invocations-voicelive` -> `Hello World Invocations Voicelive`
- *   `01-basic` -> `Basic`
+ * numeric ordering prefix (`09-`, `12_`) so upstream reorderings don't bleed
+ * into the picker, then converts dash/underscore tokens into Title Case
+ * words:  `09-declarative-customer-support` -> `Declarative Customer Support`.
  *
  * @param {string} samplePath
  * @returns {string}
@@ -693,20 +694,11 @@ async function autoFillDisplayFields(templates, commitSha) {
         }
     }
 
-    // Flag any template still missing fields after all fallbacks ran.
-    // displayName always gets filled by the folder-name fallback above, so in
-    // practice this only fires for descriptions — but check both in case the
-    // fallback ever regresses.
+    // displayName always gets filled by the folder-name fallback above, so
+    // anomaly detection here is description-only.
     for (const template of templates) {
-        const missing = [];
-        if (!template.displayName) {
-            missing.push('displayName');
-        }
         if (!template.description) {
-            missing.push('description');
-        }
-        if (missing.length > 0) {
-            warn(`Template "${template.path}" is missing: ${missing.join(', ')}. PM should fill these before merge.`);
+            warn(`Template "${template.path}" is missing: description. PM should fill it before merge.`);
         }
     }
 }
@@ -719,14 +711,15 @@ async function main() {
     const templates = await scanTemplates(commitSha);
     console.log(`Found ${templates.length} templates`);
 
-    // Step 1: Preserve existing PM-edited or previously auto-filled values
+    // Step 1: Preserve existing PM-curated displayName/description values.
     mergeExistingDisplayFields(templates);
 
     // Step 2: Apply source-controlled per-path overrides (structural fields like
     // `framework` that the upstream tree layout cannot express on its own).
     applyOverrides(templates, loadOverrides());
 
-    // Step 3: Auto-fill remaining empty fields (LLM if configured, else directory name fallback)
+    // Step 3: Fill remaining empties — displayName from folder name (always),
+    // description from the LLM when configured.
     await autoFillDisplayFields(templates, commitSha);
 
     const dimensions = buildDimensions(templates);
@@ -741,9 +734,7 @@ async function main() {
     };
 
     const outputDir = dirname(OUTPUT_PATH);
-    if (!existsSync(outputDir)) {
-        mkdirSync(outputDir, { recursive: true });
-    }
+    mkdirSync(outputDir, { recursive: true });
     writeFileSync(OUTPUT_PATH, JSON.stringify(catalog, null, 4) + '\n', 'utf-8');
 
     console.log(`Wrote ${OUTPUT_PATH}`);
@@ -783,8 +774,7 @@ function writeSummary(templateCount) {
         lines.push('These were logged during generation and may need human attention before merging:');
         lines.push('');
         for (const message of warnings) {
-            // Escape pipes so the message renders cleanly even if used inside a future table.
-            lines.push(`- ${message.replace(/\|/g, '\\|')}`);
+            lines.push(`- ${message}`);
         }
         lines.push('');
     } else {

--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -17,7 +17,7 @@
  *   SAMPLES_REPO_URL    Source repo URL (defaults to https://github.com/microsoft-foundry/foundry-samples/).
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, appendFileSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -71,6 +71,24 @@ const TEMPLATE_SELECTION = {
 
 // Path segments must be alphanumeric, hyphens, underscores, or dots
 const SAFE_PATH_SEGMENT = /^[a-zA-Z0-9._-]+$/;
+
+/**
+ * Collected anomaly messages surfaced in CI step summary so reviewers do not
+ * silently merge a catalog with missing/derived data. Always populated, even
+ * when running locally without a step-summary file.
+ * @type {string[]}
+ */
+const warnings = [];
+
+/**
+ * Record a warning that should appear in the CI step summary, and mirror it
+ * to stderr for live log visibility.
+ * @param {string} message
+ */
+function warn(message) {
+    warnings.push(message);
+    console.warn(`WARN: ${message}`);
+}
 
 /**
  * @param {string} url
@@ -135,23 +153,85 @@ function parseCommitShaArg() {
 }
 
 /**
- * List subdirectory names under a given API path.
- * @param {string} apiPath
+ * Fetch the full recursive git tree for a ref. One API call covers the entire
+ * `samples/` hierarchy, which is much cheaper (and more accurate) than walking
+ * the `/contents/` endpoint level-by-level — and it lets us discover samples
+ * at arbitrary nesting depths (e.g. `bring-your-own/voicelive/<template>`)
+ * without hard-coding the layout.
+ *
  * @param {string} ref
- * @returns {Promise<string[]>}
+ * @returns {Promise<{tree: Array<{path: string, type: string}>, truncated: boolean}>}
  */
-async function listDirs(apiPath, ref) {
-    try {
-        const items = await fetchJson(`${SAMPLES_REPO_API}/contents/${apiPath}?ref=${ref}`);
-        if (!Array.isArray(items)) {
-            return [];
+async function fetchRepoTree(ref) {
+    const data = await fetchJson(`${SAMPLES_REPO_API}/git/trees/${ref}?recursive=1`);
+    const tree = Array.isArray(data?.tree) ? data.tree : [];
+    return { tree, truncated: Boolean(data?.truncated) };
+}
+
+/**
+ * Find sample template directories under a `hosted-agents/<framework>/` prefix.
+ * A template is identified by the presence of an `agent.yaml`. When nested
+ * agent.yaml files exist (e.g. a sub-agent declared inside a parent sample),
+ * only the OUTERMOST one is treated as a catalog template — the inner files
+ * are part of the parent sample. Hidden directories (segments beginning with
+ * `.`, e.g. `.claude/skills`) are skipped, as are segments that fail the
+ * `SAFE_PATH_SEGMENT` check.
+ *
+ * @param {Array<{path: string, type: string}>} tree
+ * @param {string} prefix Path prefix ending in `/`, e.g. `samples/python/hosted-agents/agent-framework/`.
+ * @returns {string[]} Repo-relative template directory paths, outermost only.
+ */
+function findTemplateDirsUnder(tree, prefix) {
+    const candidates = tree
+        .filter((entry) => entry.type === 'blob' && entry.path.startsWith(prefix) && entry.path.endsWith('/agent.yaml'))
+        .map((entry) => entry.path.slice(0, -'/agent.yaml'.length))
+        .filter((dir) => {
+            const rel = dir.slice(prefix.length);
+            if (!rel) {
+                return false;
+            }
+            return rel.split('/').every((seg) => isSafePathSegment(seg));
+        })
+        // Sort by length so outermost templates are visited first.
+        .sort((a, b) => a.length - b.length);
+
+    /** @type {string[]} */
+    const outermost = [];
+    for (const dir of candidates) {
+        if (!outermost.some((existing) => dir.startsWith(`${existing}/`))) {
+            outermost.push(dir);
         }
-        return items
-            .filter((item) => item.type === 'dir' && isSafePathSegment(String(item.name)))
-            .map((item) => String(item.name));
-    } catch {
-        return [];
     }
+    return outermost;
+}
+
+/**
+ * Infer protocol when `agent.yaml` does not declare one explicitly. Looks for
+ * a `responses` or `invocations` segment in the path, then for the substring
+ * in the leaf directory name (common for samples like
+ * `hello-world-invocations-voicelive`). Falls back to `responses` and emits a
+ * warning so the catalog reviewer can verify the choice.
+ *
+ * @param {string} templatePath
+ * @returns {'responses' | 'invocations'}
+ */
+function inferProtocolFromPath(templatePath) {
+    const segments = templatePath.split('/');
+    if (segments.includes('responses')) {
+        return 'responses';
+    }
+    if (segments.includes('invocations')) {
+        return 'invocations';
+    }
+    const leaf = segments[segments.length - 1].toLowerCase();
+    if (leaf.includes('invocations')) {
+        return 'invocations';
+    }
+    if (leaf.includes('responses')) {
+        return 'responses';
+    }
+    warn(`Could not infer protocol for "${templatePath}"; defaulting to "responses". Add a "- protocol:" entry to agent.yaml or a sample-overrides.json entry to silence this.`);
+    return 'responses';
 }
 
 /**
@@ -325,7 +405,7 @@ ${readmeContent.substring(0, 2000)}`;
         });
 
         if (!response.ok) {
-            console.warn(`LLM API returned ${response.status} for ${samplePath}`);
+            warn(`LLM API returned ${response.status} for ${samplePath}; will fall back to directory-name displayName and leave description empty.`);
             return null;
         }
 
@@ -348,7 +428,7 @@ ${readmeContent.substring(0, 2000)}`;
 
         return { displayName, description };
     } catch (/** @type {any} */ err) {
-        console.warn(`LLM call failed for ${samplePath}: ${err.message}`);
+        warn(`LLM call failed for ${samplePath}: ${err.message}`);
         return null;
     }
 }
@@ -368,7 +448,14 @@ function displayNameFromPath(samplePath) {
 }
 
 /**
- * Scan the foundry-samples repo and build the flat template list.
+ * Scan the foundry-samples repo and build the flat template list. Uses one
+ * recursive git-tree call to enumerate every `agent.yaml` under each
+ * `<language>/hosted-agents/<framework>/` prefix, regardless of intermediate
+ * directories. This supports both the canonical layout
+ * (`<framework>/<protocol>/<template>`), the flat layout
+ * (`<framework>/<template>`), and category-grouped layouts such as
+ * `bring-your-own/voicelive/hello-world-invocations-voicelive`.
+ *
  * @param {string} commitSha
  * @returns {Promise<Array<{language: string, framework: string, protocol: string, displayName: string, description: string, path: string, requiresModel: boolean}>>}
  */
@@ -376,73 +463,32 @@ async function scanTemplates(commitSha) {
     /** @type {Array<{language: string, framework: string, protocol: string, displayName: string, description: string, path: string, requiresModel: boolean}>} */
     const templates = [];
 
+    const { tree, truncated } = await fetchRepoTree(commitSha);
+    if (truncated) {
+        warn(`GitHub git-tree API returned truncated=true for ${commitSha}; some samples may be missing from the catalog. Consider pinning to a smaller subtree or re-running.`);
+    }
+
     for (const language of LANGUAGES) {
-        const hostedRoot = `samples/${language}/hosted-agents`;
-
         for (const framework of FRAMEWORKS) {
-            const frameworkPath = `${hostedRoot}/${framework}`;
-            const subdirs = await listDirs(frameworkPath, commitSha);
+            const prefix = `samples/${language}/hosted-agents/${framework}/`;
+            const templateDirs = findTemplateDirsUnder(tree, prefix);
 
-            const protocolDirs = subdirs.filter((d) => d === 'responses' || d === 'invocations');
-            const directTemplateDirs = subdirs.filter(
-                (d) => d !== 'responses' && d !== 'invocations' && d !== 'README.md'
-            );
-
-            // Templates grouped by protocol subdirectories
-            for (const protocolDir of protocolDirs) {
-                const protocolPath = `${frameworkPath}/${protocolDir}`;
-                const templateDirs = await listDirs(protocolPath, commitSha);
-
-                for (const templateDir of templateDirs) {
-                    const templatePath = `${protocolPath}/${templateDir}`;
-                    const agentInfo = await fetchAgentYaml(templatePath, commitSha);
-
-                    /** @type {'responses' | 'invocations'} */
-                    let protocol = /** @type {'responses' | 'invocations'} */ (protocolDir);
-                    let requiresModel = true;
-                    if (agentInfo) {
-                        requiresModel = agentInfo.hasModelEnv;
-                        if (agentInfo.protocols.length > 0) {
-                            protocol = agentInfo.protocols[0];
-                        }
-                    }
-                    // Only consult agent.manifest.yaml when agent.yaml exists
-                    // and reported no model env; other cases already default to `true`.
-                    if (agentInfo && !agentInfo.hasModelEnv) {
-                        const manifestInfo = await fetchAgentManifestYaml(templatePath, commitSha);
-                        if (manifestInfo?.hasModelResource) {
-                            requiresModel = true;
-                        }
-                    }
-
-                    templates.push({
-                        language,
-                        framework,
-                        protocol,
-                        displayName: '',
-                        description: '',
-                        path: templatePath,
-                        requiresModel,
-                    });
-                }
-            }
-
-            // Templates directly under framework dir (e.g. csharp/agent-framework/hello-world)
-            for (const templateDir of directTemplateDirs) {
-                const templatePath = `${frameworkPath}/${templateDir}`;
+            for (const templatePath of templateDirs) {
                 const agentInfo = await fetchAgentYaml(templatePath, commitSha);
+                if (!agentInfo) {
+                    warn(`Could not fetch or parse agent.yaml for "${templatePath}"; skipping this template.`);
+                    continue;
+                }
 
                 /** @type {'responses' | 'invocations'} */
-                let protocol = 'responses';
-                let requiresModel = true;
-                if (agentInfo) {
-                    requiresModel = agentInfo.hasModelEnv;
-                    if (agentInfo.protocols.length > 0) {
-                        protocol = agentInfo.protocols[0];
-                    }
-                }
-                // See comment in the protocolDirs loop above.
-                if (agentInfo && !agentInfo.hasModelEnv) {
+                const protocol = agentInfo.protocols.length > 0
+                    ? agentInfo.protocols[0]
+                    : inferProtocolFromPath(templatePath);
+
+                let requiresModel = agentInfo.hasModelEnv;
+                // Only consult agent.manifest.yaml when agent.yaml reported no
+                // model env; otherwise we already default to `true`.
+                if (!requiresModel) {
                     const manifestInfo = await fetchAgentManifestYaml(templatePath, commitSha);
                     if (manifestInfo?.hasModelResource) {
                         requiresModel = true;
@@ -522,7 +568,7 @@ function mergeExistingDisplayFields(templates) {
             }
         }
     } catch (/** @type {any} */ err) {
-        console.warn(`Warning: could not read existing catalog: ${err.message}`);
+        warn(`Could not read existing catalog at ${OUTPUT_PATH}: ${err.message}. Existing displayName/description values were NOT preserved this run.`);
     }
 }
 
@@ -547,7 +593,7 @@ function loadOverrides() {
             }
         }
     } catch (/** @type {any} */ err) {
-        console.warn(`Warning: could not read sample-overrides.json: ${err.message}`);
+        warn(`Could not read sample-overrides.json: ${err.message}`);
     }
     return byPath;
 }
@@ -577,7 +623,7 @@ function applyOverrides(templates, overrides) {
     }
     for (const path of overrides.keys()) {
         if (!seenPaths.has(path)) {
-            console.warn(`Warning: override for "${path}" did not match any scanned template; check sample-overrides.json.`);
+            warn(`Override for "${path}" did not match any scanned template; check sample-overrides.json (upstream may have moved or renamed the sample).`);
         }
     }
 }
@@ -622,6 +668,23 @@ async function autoFillDisplayFields(templates, commitSha) {
             template.displayName = displayNameFromPath(template.path);
         }
     }
+
+    // Flag any template still missing fields after all fallbacks ran. displayName
+    // is always filled by the directory-name fallback above, so this is mostly
+    // about description — but check both for completeness in case the fallback
+    // ever regresses.
+    for (const template of templates) {
+        const missing = [];
+        if (!template.displayName) {
+            missing.push('displayName');
+        }
+        if (!template.description) {
+            missing.push('description');
+        }
+        if (missing.length > 0) {
+            warn(`Template "${template.path}" is missing: ${missing.join(', ')}. PM should fill these before merge.`);
+        }
+    }
 }
 
 async function main() {
@@ -660,6 +723,56 @@ async function main() {
     writeFileSync(OUTPUT_PATH, JSON.stringify(catalog, null, 4) + '\n', 'utf-8');
 
     console.log(`Wrote ${OUTPUT_PATH}`);
+
+    writeSummary(templates.length);
+}
+
+/**
+ * Append a Markdown report to `$GITHUB_STEP_SUMMARY` (when running in CI) that
+ * surfaces the warnings collected during this run. Reviewers otherwise have
+ * to scroll through raw job logs to notice anomalies like templates missing
+ * descriptions or unmatched overrides. Locally (no env var) this is a no-op.
+ *
+ * @param {number} templateCount
+ */
+function writeSummary(templateCount) {
+    const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+    if (!summaryPath) {
+        if (warnings.length > 0) {
+            console.warn(`\nCatalog generation produced ${warnings.length} warning(s) (see WARN lines above).`);
+        }
+        return;
+    }
+
+    const lines = [
+        '',
+        '## Sample Catalog Generation',
+        '',
+        `- Templates discovered: **${templateCount}**`,
+        `- Warnings emitted: **${warnings.length}**`,
+        '',
+    ];
+
+    if (warnings.length > 0) {
+        lines.push('### ⚠ Anomalies');
+        lines.push('');
+        lines.push('These were logged during generation and may need human attention before merging:');
+        lines.push('');
+        for (const message of warnings) {
+            // Escape pipes so the message renders cleanly even if used inside a future table.
+            lines.push(`- ${message.replace(/\|/g, '\\|')}`);
+        }
+        lines.push('');
+    } else {
+        lines.push('No anomalies detected. ✅');
+        lines.push('');
+    }
+
+    try {
+        appendFileSync(summaryPath, lines.join('\n'), 'utf-8');
+    } catch (/** @type {any} */ err) {
+        console.warn(`Could not append to GITHUB_STEP_SUMMARY: ${err.message}`);
+    }
 }
 
 main().catch((err) => {

--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -132,12 +132,17 @@ async function fetchText(url) {
 }
 
 /**
- * Validate that a path segment is safe (no traversal, no special chars).
+ * Validate that a path segment is safe: no traversal, no special chars, no
+ * leading-dot directories (e.g. `.claude`, `.github`) which are tooling
+ * metadata, not sample templates.
  * @param {string} segment
  * @returns {boolean}
  */
 function isSafePathSegment(segment) {
-    return SAFE_PATH_SEGMENT.test(segment) && segment !== '..' && segment !== '.';
+    if (segment === '.' || segment === '..' || segment.startsWith('.')) {
+        return false;
+    }
+    return SAFE_PATH_SEGMENT.test(segment);
 }
 
 /**
@@ -438,10 +443,36 @@ ${readmeContent.substring(0, 2000)}`;
 }
 
 /**
+ * Brand and acronym casing overrides applied during displayName derivation.
+ * Keys are lower-case tokens; values are the canonical user-facing rendering.
+ * Add entries here when a new acronym or brand appears in a sample folder
+ * name so the template picker doesn't show "Github" / "Mcp" / "Sdk".
+ * @type {Record<string, string>}
+ */
+const DISPLAY_NAME_TOKEN_CASING = {
+    ag: 'AG',
+    ai: 'AI',
+    api: 'API',
+    aws: 'AWS',
+    cli: 'CLI',
+    gcp: 'GCP',
+    github: 'GitHub',
+    llm: 'LLM',
+    mcp: 'MCP',
+    openai: 'OpenAI',
+    rag: 'RAG',
+    sdk: 'SDK',
+    sso: 'SSO',
+    ui: 'UI',
+};
+
+/**
  * Derive a displayName from the template's directory name. Strips a leading
  * numeric ordering prefix (`09-`, `12_`) so upstream reorderings don't bleed
  * into the picker, then converts dash/underscore tokens into Title Case
- * words:  `09-declarative-customer-support` -> `Declarative Customer Support`.
+ * words and applies `DISPLAY_NAME_TOKEN_CASING` for known acronyms/brands:
+ * `09-declarative-customer-support` -> `Declarative Customer Support`,
+ * `azure-search-rag` -> `Azure Search RAG`.
  *
  * @param {string} samplePath
  * @returns {string}
@@ -452,7 +483,7 @@ function displayNameFromPath(samplePath) {
         .replace(/^\d+[-_]/, '')
         .split(/[-_]/)
         .filter((w) => w.length > 0)
-        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .map((w) => DISPLAY_NAME_TOKEN_CASING[w.toLowerCase()] ?? (w.charAt(0).toUpperCase() + w.slice(1)))
         .join(' ');
 }
 

--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -576,6 +576,7 @@ function mergeExistingDisplayFields(templates) {
             }
         }
 
+        const scannedPaths = new Set(templates.map((t) => t.path));
         for (const template of templates) {
             const prev = existingByPath.get(template.path);
             if (prev) {
@@ -586,6 +587,17 @@ function mergeExistingDisplayFields(templates) {
                     template.description = prev.description;
                 }
             }
+        }
+        // Surface paths that exist in the prior catalog but were not produced
+        // by this scan — upstream likely renamed or removed the sample, and any
+        // PM-edited displayName/description on it has been dropped.
+        for (const [path, prev] of existingByPath) {
+            if (scannedPaths.has(path)) {
+                continue;
+            }
+            const hadEdits = Boolean(prev.displayName || prev.description);
+            const suffix = hadEdits ? ' Previously-edited displayName/description were dropped.' : '';
+            warn(`Template "${path}" was in the previous catalog but no longer matches any scanned sample (upstream may have renamed or removed it).${suffix}`);
         }
     } catch (/** @type {any} */ err) {
         warn(`Could not read existing catalog at ${OUTPUT_PATH}: ${err.message}. Existing displayName/description values were NOT preserved this run.`);

--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -347,10 +347,15 @@ async function fetchReadme(samplePath, ref) {
 }
 
 /**
- * Call Azure OpenAI to generate displayName and description from README content.
+ * Call Azure OpenAI to generate a description from README content. We
+ * intentionally do NOT ask the LLM for displayName — the folder name (with
+ * numeric-prefix stripped, dashes turned into spaces, and Title Case)
+ * produces more consistent results across the catalog and is easier for PMs
+ * to predict at review time.
+ *
  * @param {string} readmeContent
  * @param {string} samplePath
- * @returns {Promise<{ displayName: string, description: string } | null>}
+ * @returns {Promise<{ description: string } | null>}
  */
 async function generateWithLLM(readmeContent, samplePath) {
     if (!AZURE_OPENAI_ENDPOINT || !AZURE_OPENAI_API_KEY) {
@@ -359,28 +364,23 @@ async function generateWithLLM(readmeContent, samplePath) {
 
     const apiUrl = `${AZURE_OPENAI_ENDPOINT}/openai/deployments/${AZURE_OPENAI_DEPLOYMENT}/chat/completions?api-version=2024-08-01-preview`;
 
-    const systemPrompt = `You generate metadata for a VS Code template picker.
-The user has already selected language, framework, and protocol before seeing these items.
+    const systemPrompt = `You generate one-sentence descriptions for a VS Code template picker.
+The user has already selected language, framework, and protocol before seeing these items, so the description must NOT repeat those choices.
 
-Rules for displayName:
-- 1-3 words, max 4 words
-- Describe the core capability only (e.g. "Hello World", "Multi-Turn Chat", "Local Tools", "MCP Tools", "Note-Taking")
-- Do NOT include: language names, protocol names, framework names, "Agent", "Hosted", "Sample", "Demo"
-- Use Title Case
-
-Rules for description:
+Rules:
 - One sentence, max 100 characters
 - Plain text, no markdown
-- Describe what the sample does, not how
+- Describe what the sample does, not how it is implemented
+- Do NOT include language names, protocol names, framework names, or words like "Sample" / "Demo"
 
 Examples:
-  {"displayName": "Hello World", "description": "Minimal agent that echoes a response from a Foundry model."}
-  {"displayName": "Multi-Turn Chat", "description": "Conversational agent with multi-turn session history."}
-  {"displayName": "Local Tools", "description": "Agent with local function tools for hotel search."}
-  {"displayName": "MCP Tools", "description": "Agent that discovers and invokes tools from a remote MCP server."}
-  {"displayName": "Note-Taking", "description": "Agent that saves and retrieves notes using function calling."}
+  {"description": "Minimal agent that echoes a response from a Foundry model."}
+  {"description": "Conversational agent with multi-turn session history."}
+  {"description": "Agent with local function tools for hotel search."}
+  {"description": "Agent that discovers and invokes tools from a remote MCP server."}
+  {"description": "Agent that saves and retrieves notes using function calling."}
 
-Respond ONLY with a JSON object: {"displayName": "...", "description": "..."}`;
+Respond ONLY with a JSON object: {"description": "..."}`;
 
     const userPrompt = `Path: ${samplePath}
 
@@ -393,7 +393,7 @@ ${readmeContent.substring(0, 2000)}`;
             { role: 'user', content: userPrompt },
         ],
         temperature: 0,
-        max_tokens: 150,
+        max_tokens: 120,
     };
 
     try {
@@ -407,7 +407,7 @@ ${readmeContent.substring(0, 2000)}`;
         });
 
         if (!response.ok) {
-            warn(`LLM API returned ${response.status} for ${samplePath}; will fall back to directory-name displayName and leave description empty.`);
+            warn(`LLM API returned ${response.status} for ${samplePath}; description will be left empty.`);
             return null;
         }
 
@@ -421,14 +421,12 @@ ${readmeContent.substring(0, 2000)}`;
         const jsonStr = content.replace(/^```json\s*/, '').replace(/\s*```$/, '');
         const parsed = JSON.parse(jsonStr);
 
-        const displayName = typeof parsed.displayName === 'string' ? parsed.displayName.trim() : '';
         const description = typeof parsed.description === 'string' ? parsed.description.trim() : '';
-
-        if (!displayName && !description) {
+        if (!description) {
             return null;
         }
 
-        return { displayName, description };
+        return { description };
     } catch (/** @type {any} */ err) {
         warn(`LLM call failed for ${samplePath}: ${err.message}`);
         return null;
@@ -436,15 +434,23 @@ ${readmeContent.substring(0, 2000)}`;
 }
 
 /**
- * Fallback: derive displayName from directory name.
+ * Derive a displayName from the template's directory name. Strips a leading
+ * numeric ordering prefix (`09-`, `12-`) so reorderings upstream don't bleed
+ * into the picker, then converts dash-separated tokens into Title Case words.
+ *
+ *   `09-declarative-customer-support` -> `Declarative Customer Support`
+ *   `hello-world-invocations-voicelive` -> `Hello World Invocations Voicelive`
+ *   `01-basic` -> `Basic`
+ *
  * @param {string} samplePath
  * @returns {string}
  */
 function displayNameFromPath(samplePath) {
     const dirName = samplePath.split('/').pop() || '';
     return dirName
-        .replace(/^\d+-/, '')
-        .split('-')
+        .replace(/^\d+[-_]/, '')
+        .split(/[-_]/)
+        .filter((w) => w.length > 0)
         .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
         .join(' ');
 }
@@ -642,50 +648,55 @@ function applyOverrides(templates, overrides) {
 }
 
 /**
- * Auto-fill empty displayName and description using LLM (with README as context).
- * Falls back to directory-name-based displayName if LLM is unavailable.
- * Only fills fields that are still empty after merging existing values.
+ * Auto-fill empty displayName and description fields.
+ *
+ * displayName is ALWAYS derived from the template's directory name when empty
+ * — the LLM is not consulted, because folder-name derivation is deterministic
+ * and PM-predictable. Existing PM-curated displayName values are preserved by
+ * the prior `mergeExistingDisplayFields` step, so this only affects newly
+ * scanned templates.
+ *
+ * description is filled by the LLM (when configured) using the sample's
+ * README as context. Without LLM credentials the description stays empty and
+ * gets surfaced as an anomaly in the step summary.
+ *
  * @param {Array<{displayName: string, description: string, path: string}>} templates
  * @param {string} commitSha
  */
 async function autoFillDisplayFields(templates, commitSha) {
-    const emptyTemplates = templates.filter((t) => !t.displayName || !t.description);
-    if (emptyTemplates.length === 0) {
-        console.log('All templates already have displayName and description.');
-        return;
-    }
-
-    const hasLLM = Boolean(AZURE_OPENAI_ENDPOINT && AZURE_OPENAI_API_KEY);
-    console.log(
-        `Auto-filling ${emptyTemplates.length} templates${hasLLM ? ' using LLM' : ' using directory name fallback'}...`
-    );
-
-    for (const template of emptyTemplates) {
-        if (hasLLM) {
-            const readme = await fetchReadme(template.path, commitSha);
-            if (readme) {
-                const result = await generateWithLLM(readme, template.path);
-                if (result) {
-                    if (!template.displayName && result.displayName) {
-                        template.displayName = result.displayName;
-                    }
-                    if (!template.description && result.description) {
-                        template.description = result.description;
-                    }
-                }
-            }
-        }
-
-        // Fallback: derive displayName from directory name if still empty
+    // Fill displayName first — deterministic, no API calls.
+    for (const template of templates) {
         if (!template.displayName) {
             template.displayName = displayNameFromPath(template.path);
         }
     }
 
-    // Flag any template still missing fields after all fallbacks ran. displayName
-    // is always filled by the directory-name fallback above, so this is mostly
-    // about description — but check both for completeness in case the fallback
-    // ever regresses.
+    const needsDescription = templates.filter((t) => !t.description);
+    if (needsDescription.length === 0) {
+        console.log('All templates already have a description.');
+    } else {
+        const hasLLM = Boolean(AZURE_OPENAI_ENDPOINT && AZURE_OPENAI_API_KEY);
+        if (hasLLM) {
+            console.log(`Generating descriptions for ${needsDescription.length} templates using LLM...`);
+            for (const template of needsDescription) {
+                const readme = await fetchReadme(template.path, commitSha);
+                if (!readme) {
+                    continue;
+                }
+                const result = await generateWithLLM(readme, template.path);
+                if (result?.description) {
+                    template.description = result.description;
+                }
+            }
+        } else {
+            console.log(`${needsDescription.length} templates need a description but no LLM is configured; leaving empty (will be flagged as anomalies).`);
+        }
+    }
+
+    // Flag any template still missing fields after all fallbacks ran.
+    // displayName always gets filled by the folder-name fallback above, so in
+    // practice this only fires for descriptions — but check both in case the
+    // fallback ever regresses.
     for (const template of templates) {
         const missing = [];
         if (!template.displayName) {

--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -48,10 +48,12 @@ const DIMENSION_DEFAULTS = {
     framework: {
         title: 'Select a Framework',
         placeholder: 'Choose the framework for your agent',
+        // Insertion order here drives the option order in the generated catalog
+        // (see buildDimensions). Keep the most actively promoted framework first.
         options: {
+            'copilot-sdk': 'Copilot SDK',
             'agent-framework': 'Agent Framework',
             'bring-your-own': 'Bring Your Own',
-            'copilot-sdk': 'Copilot SDK',
         },
     },
     protocol: {
@@ -513,6 +515,12 @@ async function scanTemplates(commitSha) {
 
 /**
  * Build the dimensions section from discovered templates and defaults.
+ * Option order follows the insertion order of `DIMENSION_DEFAULTS[dim].options`
+ * so we have UX control (e.g. promote `copilot-sdk` ahead of
+ * `agent-framework`). Any id seen in the scanned templates but not declared in
+ * the defaults is appended at the end in alphabetical order, so a new
+ * framework added upstream does not break the build — just shows up last.
+ *
  * @param {Array<{language: string, framework: string, protocol: string}>} templates
  */
 function buildDimensions(templates) {
@@ -521,8 +529,13 @@ function buildDimensions(templates) {
 
     for (const dimKey of /** @type {const} */ (['language', 'framework', 'protocol'])) {
         const defaults = DIMENSION_DEFAULTS[dimKey];
-        const seenIds = [...new Set(templates.map((t) => t[dimKey]))].sort();
-        const options = seenIds.map((id) => ({
+        const seenIds = new Set(templates.map((t) => t[dimKey]));
+        const declaredOrder = Object.keys(defaults.options);
+        const orderedIds = [
+            ...declaredOrder.filter((id) => seenIds.has(id)),
+            ...[...seenIds].filter((id) => !declaredOrder.includes(id)).sort(),
+        ];
+        const options = orderedIds.map((id) => ({
             id,
             displayName: defaults.options[id] || id,
         }));

--- a/.github/workflows/sync-sample-catalog.yml
+++ b/.github/workflows/sync-sample-catalog.yml
@@ -149,7 +149,7 @@ jobs:
 
             ## What changed
             - New templates added or removed based on the upstream repo structure.
-            - `commitSha` updated to the latest commit on `main`.
+            - `commitSha` pinned to the upstream commit supplied via the `commit_sha` workflow input.
             - `requiresModel` and `protocol` values re-derived from each sample's `agent.yaml`.
             - `displayName` derived from each template's folder name; `description` LLM-generated when empty.
             - PM-edited `displayName` and `description` values are preserved from the previous catalog.

--- a/.github/workflows/sync-sample-catalog.yml
+++ b/.github/workflows/sync-sample-catalog.yml
@@ -158,6 +158,22 @@ jobs:
       - name: Report PR result
         if: steps.diff.outputs.has_changes == 'true'
         shell: bash
+        env:
+          PR_OPERATION: ${{ steps.cpr.outputs.pull-request-operation }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          echo "PR operation: ${{ steps.cpr.outputs.pull-request-operation }}"
-          echo "PR URL: ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "PR operation: $PR_OPERATION"
+          echo "PR URL: $PR_URL"
+
+          {
+            echo
+            echo "## Pull Request"
+            echo
+            if [[ -n "$PR_URL" ]]; then
+              echo "- Operation: \`$PR_OPERATION\`"
+              echo "- PR: [#${PR_NUMBER:-?}]($PR_URL)"
+            else
+              echo "- No pull request was created or updated (peter-evans/create-pull-request returned no URL)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-sample-catalog.yml
+++ b/.github/workflows/sync-sample-catalog.yml
@@ -12,6 +12,12 @@ permissions:
   contents: write
   pull-requests: write
 
+# A single in-flight sync at a time — a re-trigger cancels any earlier run
+# rather than racing it for the same PR branch.
+concurrency:
+  group: sync-sample-catalog-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -145,11 +151,12 @@ jobs:
             - New templates added or removed based on the upstream repo structure.
             - `commitSha` updated to the latest commit on `main`.
             - `requiresModel` and `protocol` values re-derived from each sample's `agent.yaml`.
+            - `displayName` derived from each template's folder name; `description` LLM-generated when empty.
             - PM-edited `displayName` and `description` values are preserved from the previous catalog.
 
             ## Reviewer Checks
             - Confirm new templates have correct `language`, `framework`, and `protocol` values.
-            - Fill in `displayName` and `description` for any new templates (empty by default).
+            - Review the auto-generated `description` for any new templates.
             - Confirm no PM-edited display fields were accidentally lost.
           labels: ${{ steps.labels.outputs.labels }}
           add-paths: |

--- a/samples/hosted-agent/sample-catalog.json
+++ b/samples/hosted-agent/sample-catalog.json
@@ -233,7 +233,7 @@
             "displayName": "GitHub Copilot",
             "description": "Agent streams Copilot session events with multi-turn support and pirate-themed jokes.",
             "path": "samples/python/hosted-agents/bring-your-own/invocations/github-copilot",
-            "requiresModel": true
+            "requiresModel": false
         },
         {
             "language": "python",

--- a/samples/hosted-agent/sample-catalog.json
+++ b/samples/hosted-agent/sample-catalog.json
@@ -1,19 +1,19 @@
 {
     "commitSha": "6ef684d31806d22f30163aa78536f2b50af05d7c",
     "repo": "https://github.com/microsoft-foundry/foundry-samples/",
-    "generatedAt": "2026-05-25T08:45:57Z",
+    "generatedAt": "2026-05-26T08:10:51Z",
     "dimensions": {
         "language": {
             "title": "Select a Language",
             "placeholder": "Choose the language for your agent",
             "options": [
                 {
-                    "id": "csharp",
-                    "displayName": "C# (.NET)"
-                },
-                {
                     "id": "python",
                     "displayName": "Python"
+                },
+                {
+                    "id": "csharp",
+                    "displayName": "C# (.NET)"
                 }
             ]
         },
@@ -22,16 +22,16 @@
             "placeholder": "Choose the framework for your agent",
             "options": [
                 {
+                    "id": "copilot-sdk",
+                    "displayName": "Copilot SDK"
+                },
+                {
                     "id": "agent-framework",
                     "displayName": "Agent Framework"
                 },
                 {
                     "id": "bring-your-own",
                     "displayName": "Bring Your Own"
-                },
-                {
-                    "id": "copilot-sdk",
-                    "displayName": "Copilot SDK"
                 }
             ]
         },
@@ -40,12 +40,12 @@
             "placeholder": "Choose the protocol for your agent",
             "options": [
                 {
-                    "id": "invocations",
-                    "displayName": "Invocations API"
-                },
-                {
                     "id": "responses",
                     "displayName": "Responses API"
+                },
+                {
+                    "id": "invocations",
+                    "displayName": "Invocations API"
                 }
             ]
         }
@@ -58,36 +58,9 @@
         {
             "language": "python",
             "framework": "agent-framework",
-            "protocol": "invocations",
-            "displayName": "Session Management",
-            "description": "Agent maintains conversation history using in-memory session storage.",
-            "path": "samples/python/hosted-agents/agent-framework/invocations/01-basic",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Multi-Turn Chat",
-            "description": "Conversational agent with session history and response tracking.",
-            "path": "samples/python/hosted-agents/agent-framework/responses/01-basic",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "agent-framework",
-            "protocol": "responses",
-            "displayName": "Local Tools",
-            "description": "Agent with locally defined tools for tasks like weather lookup.",
-            "path": "samples/python/hosted-agents/agent-framework/responses/02-tools",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "agent-framework",
-            "protocol": "responses",
-            "displayName": "MCP Tools",
-            "description": "Discovers and invokes tools from a remote MCP server at runtime.",
+            "displayName": "Mcp",
+            "description": "Agent that dynamically discovers and invokes tools from a remote GitHub MCP server.",
             "path": "samples/python/hosted-agents/agent-framework/responses/03-mcp",
             "requiresModel": true
         },
@@ -95,26 +68,26 @@
             "language": "python",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Toolbox Discovery",
-            "description": "Agent that discovers and exposes tools from a centralized toolbox registry.",
-            "path": "samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox",
+            "displayName": "Basic",
+            "description": "Agent that supports multi-turn conversations with session tracking.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/01-basic",
             "requiresModel": true
         },
         {
             "language": "python",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Multi-Agent Workflow",
-            "description": "Sequential workflow with specialized agents for writing, review, and formatting.",
-            "path": "samples/python/hosted-agents/agent-framework/responses/05-workflows",
+            "displayName": "Tools",
+            "description": "Agent with custom tools like weather lookup, callable during a conversation.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/02-tools",
             "requiresModel": true
         },
         {
             "language": "python",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "File Management",
-            "description": "Agent that lists, reads, and interprets files using local and code tools.",
+            "displayName": "Files",
+            "description": "Agent that lists, reads, and interprets files using shell and code tools.",
             "path": "samples/python/hosted-agents/agent-framework/responses/06-files",
             "requiresModel": true
         },
@@ -122,9 +95,27 @@
             "language": "python",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "File-Based Skills",
-            "description": "Agent that discovers and runs local file-based skills for travel guide creation.",
+            "displayName": "Skills",
+            "description": "Agent that discovers local skills and generates PDF travel guides for cities.",
             "path": "samples/python/hosted-agents/agent-framework/responses/07-skills",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "invocations",
+            "displayName": "Basic",
+            "description": "Agent with in-memory session management for multi-turn conversations.",
+            "path": "samples/python/hosted-agents/agent-framework/invocations/01-basic",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Workflows",
+            "description": "Processes requests through slogan writing, legal review, and formatting agents in sequence.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/05-workflows",
             "requiresModel": true
         },
         {
@@ -132,7 +123,7 @@
             "framework": "agent-framework",
             "protocol": "responses",
             "displayName": "Observability",
-            "description": "Instrumented agent with diagnostics and telemetry for execution monitoring.",
+            "description": "Agent with built-in observability and telemetry for diagnostics and monitoring.",
             "path": "samples/python/hosted-agents/agent-framework/responses/08-observability",
             "requiresModel": true
         },
@@ -140,35 +131,8 @@
             "language": "python",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Customer Support",
-            "description": "Declarative workflow for multi-turn customer support triage and routing.",
-            "path": "samples/python/hosted-agents/agent-framework/responses/09-declarative-customer-support",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "agent-framework",
-            "protocol": "responses",
-            "displayName": "Azure Data Operations",
-            "description": "Performs data-plane actions on Blob Storage and Service Bus using Entra identity.",
-            "path": "samples/python/hosted-agents/agent-framework/responses/10-downstream-azure",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "agent-framework",
-            "protocol": "responses",
-            "displayName": "Search-Augmented RAG",
-            "description": "Retrieves product documentation from Azure AI Search to ground and cite answers.",
-            "path": "samples/python/hosted-agents/agent-framework/responses/11-azure-search-rag",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "agent-framework",
-            "protocol": "responses",
             "displayName": "Foundry Skills",
-            "description": "Loads behavioral guidelines from Foundry Skills at startup.",
+            "description": "Agent that loads behavioral guidelines from Foundry Skills at startup for dynamic updates.",
             "path": "samples/python/hosted-agents/agent-framework/responses/12-foundry-skills",
             "requiresModel": true
         },
@@ -176,17 +140,53 @@
             "language": "python",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Persistent Memory",
-            "description": "Agent remembers user facts across sessions using semantic memory storage.",
+            "displayName": "Foundry Memory",
+            "description": "Agent that remembers user facts across sessions using persistent semantic memory.",
             "path": "samples/python/hosted-agents/agent-framework/responses/13-foundry-memory",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Foundry Toolbox",
+            "description": "Agent that discovers and invokes centrally managed tools from a Foundry Toolbox.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Downstream Azure",
+            "description": "Agent performs data operations on Blob Storage and Service Bus using its own identity.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/10-downstream-azure",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Azure Search Rag",
+            "description": "Answers questions using product documentation and cites sources from a search index.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/11-azure-search-rag",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Declarative Customer Support",
+            "description": "Customer support agent that triages and routes requests to specialist agents.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/09-declarative-customer-support",
             "requiresModel": true
         },
         {
             "language": "python",
             "framework": "bring-your-own",
             "protocol": "invocations",
-            "displayName": "AG-UI Invocations",
-            "description": "Handles AG-UI requests and streams agent events automatically.",
+            "displayName": "Ag Ui",
+            "description": "Agent that streams AG-UI events in response to user input via HTTP POST.",
             "path": "samples/python/hosted-agents/bring-your-own/invocations/ag-ui",
             "requiresModel": true
         },
@@ -194,71 +194,8 @@
             "language": "python",
             "framework": "bring-your-own",
             "protocol": "invocations",
-            "displayName": "Streaming Invocations",
-            "description": "Streams assistant responses for plain text input via POST requests.",
-            "path": "samples/python/hosted-agents/bring-your-own/invocations/claude-agent-sdk",
-            "requiresModel": false
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "invocations",
-            "displayName": "Event-Driven Summarization",
-            "description": "Summarizes uploaded blobs and writes results to a separate container on event trigger.",
-            "path": "samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "copilot-sdk",
-            "protocol": "invocations",
-            "displayName": "Multi-Turn Chat",
-            "description": "Streams Copilot SDK session events with multi-turn conversation support.",
-            "path": "samples/python/hosted-agents/bring-your-own/invocations/github-copilot",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "invocations",
-            "displayName": "Hello World",
-            "description": "Minimal agent that returns a Foundry model response as a streaming event.",
-            "path": "samples/python/hosted-agents/bring-your-own/invocations/hello-world",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "invocations",
-            "displayName": "Human Approval Gate",
-            "description": "Agent workflow that requires human review before completing tasks.",
-            "path": "samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "invocations",
-            "displayName": "Multi-Turn Chat",
-            "description": "Conversational agent with session history and built-in time and calculator tools.",
-            "path": "samples/python/hosted-agents/bring-your-own/invocations/langgraph-chat",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "invocations",
-            "displayName": "Note-Taking",
-            "description": "Saves and retrieves notes with per-session persistence and streaming responses.",
-            "path": "samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "invocations",
-            "displayName": "Toolbox Integration",
-            "description": "Connects to a toolbox and enables tool discovery and invocation during conversation.",
+            "displayName": "Toolbox",
+            "description": "Agent connects to a toolbox server and enables tool discovery and invocation during chat.",
             "path": "samples/python/hosted-agents/bring-your-own/invocations/toolbox",
             "requiresModel": true
         },
@@ -266,8 +203,53 @@
             "language": "python",
             "framework": "bring-your-own",
             "protocol": "responses",
-            "displayName": "Background Responses",
-            "description": "Processes long-running requests and streams research analysis sections asynchronously.",
+            "displayName": "Hello World",
+            "description": "Minimal hosted agent that returns a hello world message from a Foundry model.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/hello-world",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Hello World",
+            "description": "Hosted agent that streams a Foundry model's reply as a server-sent event.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/hello-world",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Langgraph Chat",
+            "description": "Conversational agent with built-in calculator and time tools, streaming responses.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/langgraph-chat",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "copilot-sdk",
+            "protocol": "invocations",
+            "displayName": "Github Copilot",
+            "description": "Agent streams Copilot session events with multi-turn support and pirate-themed jokes.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/github-copilot",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Langgraph Chat",
+            "description": "Conversational agent with session history and built-in calculator and time tools.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/langgraph-chat",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Background Agent",
+            "description": "Handles long-running research analysis requests with background processing and streaming updates.",
             "path": "samples/python/hosted-agents/bring-your-own/responses/background-agent",
             "requiresModel": true
         },
@@ -275,53 +257,8 @@
             "language": "python",
             "framework": "bring-your-own",
             "protocol": "responses",
-            "displayName": "Toolbox Integration",
-            "description": "Connects to a Foundry toolbox and enables tool discovery and invocation during conversation.",
-            "path": "samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "responses",
-            "displayName": "Hello World",
-            "description": "Minimal agent that returns a Foundry model response using the Responses protocol.",
-            "path": "samples/python/hosted-agents/bring-your-own/responses/hello-world",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "responses",
-            "displayName": "Multi-Turn Chat",
-            "description": "Conversational agent with built-in tools and server-side session state.",
-            "path": "samples/python/hosted-agents/bring-your-own/responses/langgraph-chat",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "responses",
-            "displayName": "User Identity Tools",
-            "description": "Connects to mail, calendar, and GitHub tools for user-identity scenarios.",
-            "path": "samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "responses",
-            "displayName": "Toolbox Integration",
-            "description": "Connects to a toolbox and serves responses using loaded tools.",
-            "path": "samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox",
-            "requiresModel": true
-        },
-        {
-            "language": "python",
-            "framework": "bring-your-own",
-            "protocol": "responses",
-            "displayName": "Note-Taking",
-            "description": "Saves and retrieves notes with per-session persistence and streaming responses.",
+            "displayName": "Notetaking Agent",
+            "description": "Agent that saves and retrieves notes with per-session isolation and streaming responses.",
             "path": "samples/python/hosted-agents/bring-your-own/responses/notetaking-agent",
             "requiresModel": true
         },
@@ -329,89 +266,89 @@
             "language": "python",
             "framework": "bring-your-own",
             "protocol": "responses",
-            "displayName": "Streaming Responses",
-            "description": "Streams text responses from a Foundry-backed model using the Responses protocol.",
-            "path": "samples/python/hosted-agents/bring-your-own/responses/openai-agents-sdk",
+            "displayName": "Langgraph Toolbox",
+            "description": "Agent that dynamically loads tools from a remote toolbox and handles incoming requests.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox",
             "requiresModel": true
         },
         {
             "language": "python",
             "framework": "bring-your-own",
             "protocol": "responses",
-            "displayName": "Voicelive",
-            "description": "",
-            "path": "samples/python/hosted-agents/bring-your-own/voicelive",
+            "displayName": "Openai Agents Sdk",
+            "description": "Minimal agent that streams text responses from a Foundry-backed model.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/openai-agents-sdk",
             "requiresModel": true
         },
         {
-            "language": "csharp",
-            "framework": "agent-framework",
-            "protocol": "responses",
-            "displayName": "Retrieval Augmented Generation",
-            "description": "Answers are grounded in a knowledge base using Azure AI Search.",
-            "path": "samples/csharp/hosted-agents/agent-framework/azure-search-rag",
-            "requiresModel": true
-        },
-        {
-            "language": "csharp",
-            "framework": "agent-framework",
-            "protocol": "responses",
-            "displayName": "File Tools",
-            "description": "Answers questions using bundled and session-uploaded files as knowledge sources.",
-            "path": "samples/csharp/hosted-agents/agent-framework/file-tools",
-            "requiresModel": true
-        },
-        {
-            "language": "csharp",
-            "framework": "agent-framework",
-            "protocol": "responses",
-            "displayName": "Persistent Memory RAG",
-            "description": "Answers are grounded in user-specific memories that persist across sessions.",
-            "path": "samples/csharp/hosted-agents/agent-framework/foundry-memory-rag",
-            "requiresModel": true
-        },
-        {
-            "language": "csharp",
-            "framework": "agent-framework",
-            "protocol": "responses",
-            "displayName": "Server-Side Tools",
-            "description": "Agent that uses server-side tools from a Foundry Toolbox.",
-            "path": "samples/csharp/hosted-agents/agent-framework/foundry-toolbox-server-side",
-            "requiresModel": true
-        },
-        {
-            "language": "csharp",
-            "framework": "agent-framework",
-            "protocol": "responses",
-            "displayName": "Hello World",
-            "description": "Minimal agent that echoes a response from a Foundry model.",
-            "path": "samples/csharp/hosted-agents/agent-framework/hello-world",
-            "requiresModel": true
-        },
-        {
-            "language": "csharp",
-            "framework": "agent-framework",
+            "language": "python",
+            "framework": "bring-your-own",
             "protocol": "invocations",
-            "displayName": "Hello World",
-            "description": "Minimal agent that echoes back the input message in the response.",
-            "path": "samples/csharp/hosted-agents/agent-framework/invocations-echo-agent",
+            "displayName": "Claude Agent Sdk",
+            "description": "Streams assistant responses for plain text queries with error handling.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/claude-agent-sdk",
             "requiresModel": false
         },
         {
-            "language": "csharp",
-            "framework": "agent-framework",
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Notetaking Agent",
+            "description": "Agent that saves and retrieves notes with per-session isolation and streaming responses.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Human In The Loop",
+            "description": "Agent that generates proposals and waits for human approval before proceeding.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Event Grid Trigger",
+            "description": "Agent triggered by Azure Storage events that summarizes uploaded blobs and saves results separately.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
             "protocol": "responses",
-            "displayName": "Local Tools",
-            "description": "Assistant that searches for hotels using local function tools.",
-            "path": "samples/csharp/hosted-agents/agent-framework/local-tools",
+            "displayName": "Bring Your Own Toolbox",
+            "description": "Agent connects to a toolbox server and enables tool invocation during conversations.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Langgraph Toolbox User Identity",
+            "description": "Agent that accesses mail, calendar, and GitHub tools for user-identity scenarios.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Hello World Invocations Voicelive",
+            "description": "Minimal hosted agent for real-time voice interactions with audio transcription streaming.",
+            "path": "samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive",
             "requiresModel": true
         },
         {
             "language": "csharp",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "MCP Tools",
-            "description": "Integrates documentation search tools using client and server-side MCP connections.",
+            "displayName": "Mcp Tools",
+            "description": "Agent answers questions by searching documentation using integrated tool providers.",
             "path": "samples/csharp/hosted-agents/agent-framework/mcp-tools",
             "requiresModel": true
         },
@@ -419,8 +356,44 @@
             "language": "csharp",
             "framework": "agent-framework",
             "protocol": "responses",
+            "displayName": "Workflows",
+            "description": "Workflow chains three translation agents to show intermediate and final translations.",
+            "path": "samples/csharp/hosted-agents/agent-framework/workflows",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "File Tools",
+            "description": "Agent that answers questions using both bundled and user-uploaded session files.",
+            "path": "samples/csharp/hosted-agents/agent-framework/file-tools",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
             "displayName": "Hello World",
-            "description": "Minimal assistant that replies to user input using an AI model.",
+            "description": "Minimal hosted agent that responds to user questions and supports multi-turn conversation.",
+            "path": "samples/csharp/hosted-agents/agent-framework/hello-world",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Local Tools",
+            "description": "Hotel search assistant with tools for location, dates, and price queries.",
+            "path": "samples/csharp/hosted-agents/agent-framework/local-tools",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Simple Agent",
+            "description": "General-purpose AI assistant that replies to user input with model-generated responses.",
             "path": "samples/csharp/hosted-agents/agent-framework/simple-agent",
             "requiresModel": true
         },
@@ -428,8 +401,8 @@
             "language": "csharp",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Text Search RAG",
-            "description": "Answers questions using retrieval augmented generation from support documents.",
+            "displayName": "Text Search Rag",
+            "description": "Support agent that answers questions using external knowledge from support documents.",
             "path": "samples/csharp/hosted-agents/agent-framework/text-search-rag",
             "requiresModel": true
         },
@@ -437,53 +410,62 @@
             "language": "csharp",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Workflow Translation",
-            "description": "Sequential translation workflow through English, French, and Spanish.",
-            "path": "samples/csharp/hosted-agents/agent-framework/workflows",
+            "displayName": "Azure Search Rag",
+            "description": "Support agent answers questions using a keyword-indexed knowledge base for grounding.",
+            "path": "samples/csharp/hosted-agents/agent-framework/azure-search-rag",
             "requiresModel": true
         },
         {
             "language": "csharp",
-            "framework": "bring-your-own",
-            "protocol": "invocations",
-            "displayName": "Hello World",
-            "description": "Minimal agent that returns a Foundry model response as a streaming event.",
-            "path": "samples/csharp/hosted-agents/bring-your-own/invocations/HelloWorld",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Foundry Memory Rag",
+            "description": "Personal coach agent that remembers user preferences and goals across sessions.",
+            "path": "samples/csharp/hosted-agents/agent-framework/foundry-memory-rag",
             "requiresModel": true
         },
         {
             "language": "csharp",
-            "framework": "bring-your-own",
+            "framework": "agent-framework",
             "protocol": "invocations",
-            "displayName": "Human Approval Gate",
-            "description": "Agent workflow that requires human review and approval before completing tasks.",
-            "path": "samples/csharp/hosted-agents/bring-your-own/invocations/human-in-the-loop",
-            "requiresModel": true
+            "displayName": "Invocations Echo Agent",
+            "description": "Agent that echoes back input messages for testing hosting infrastructure.",
+            "path": "samples/csharp/hosted-agents/agent-framework/invocations-echo-agent",
+            "requiresModel": false
         },
         {
             "language": "csharp",
-            "framework": "bring-your-own",
-            "protocol": "invocations",
-            "displayName": "Note-Taking",
-            "description": "Saves and retrieves session-persistent notes using function calling.",
-            "path": "samples/csharp/hosted-agents/bring-your-own/invocations/notetaking-agent",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Foundry Toolbox Server Side",
+            "description": "Agent that uses tools from a Foundry Toolbox, invoked server-side by the platform.",
+            "path": "samples/csharp/hosted-agents/agent-framework/foundry-toolbox-server-side",
             "requiresModel": true
         },
         {
             "language": "csharp",
             "framework": "bring-your-own",
             "protocol": "responses",
-            "displayName": "Hello World",
-            "description": "Minimal agent that echoes a response from a Foundry model.",
+            "displayName": "HelloWorld",
+            "description": "Hosted agent that returns a hello world message from a Foundry model using the Responses API.",
             "path": "samples/csharp/hosted-agents/bring-your-own/responses/HelloWorld",
             "requiresModel": true
         },
         {
             "language": "csharp",
             "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "HelloWorld",
+            "description": "Minimal hosted agent that returns a streaming hello world response from a model.",
+            "path": "samples/csharp/hosted-agents/bring-your-own/invocations/HelloWorld",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "bring-your-own",
             "protocol": "responses",
-            "displayName": "Background Responses",
-            "description": "Processes research analysis requests asynchronously with streaming updates.",
+            "displayName": "Background Agent",
+            "description": "Handles research analysis requests asynchronously with background processing and streaming updates.",
             "path": "samples/csharp/hosted-agents/bring-your-own/responses/background-agent",
             "requiresModel": true
         },
@@ -491,9 +473,27 @@
             "language": "csharp",
             "framework": "bring-your-own",
             "protocol": "responses",
-            "displayName": "Note-Taking",
-            "description": "Saves and retrieves session-persistent notes using function calling.",
+            "displayName": "Notetaking Agent",
+            "description": "Agent that saves and retrieves session-persistent notes for each user.",
             "path": "samples/csharp/hosted-agents/bring-your-own/responses/notetaking-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Notetaking Agent",
+            "description": "Agent that saves and retrieves session-persistent notes with real-time streaming responses.",
+            "path": "samples/csharp/hosted-agents/bring-your-own/invocations/notetaking-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Human In The Loop",
+            "description": "Agent that generates proposals and waits for human approval before proceeding.",
+            "path": "samples/csharp/hosted-agents/bring-your-own/invocations/human-in-the-loop",
             "requiresModel": true
         }
     ]

--- a/samples/hosted-agent/sample-catalog.json
+++ b/samples/hosted-agent/sample-catalog.json
@@ -59,7 +59,7 @@
             "language": "python",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Mcp",
+            "displayName": "MCP",
             "description": "Agent that dynamically discovers and invokes tools from a remote GitHub MCP server.",
             "path": "samples/python/hosted-agents/agent-framework/responses/03-mcp",
             "requiresModel": true
@@ -167,7 +167,7 @@
             "language": "python",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Azure Search Rag",
+            "displayName": "Azure Search RAG",
             "description": "Answers questions using product documentation and cites sources from a search index.",
             "path": "samples/python/hosted-agents/agent-framework/responses/11-azure-search-rag",
             "requiresModel": true
@@ -185,7 +185,7 @@
             "language": "python",
             "framework": "bring-your-own",
             "protocol": "invocations",
-            "displayName": "Ag Ui",
+            "displayName": "AG UI",
             "description": "Agent that streams AG-UI events in response to user input via HTTP POST.",
             "path": "samples/python/hosted-agents/bring-your-own/invocations/ag-ui",
             "requiresModel": true
@@ -230,7 +230,7 @@
             "language": "python",
             "framework": "copilot-sdk",
             "protocol": "invocations",
-            "displayName": "Github Copilot",
+            "displayName": "GitHub Copilot",
             "description": "Agent streams Copilot session events with multi-turn support and pirate-themed jokes.",
             "path": "samples/python/hosted-agents/bring-your-own/invocations/github-copilot",
             "requiresModel": true
@@ -275,7 +275,7 @@
             "language": "python",
             "framework": "bring-your-own",
             "protocol": "responses",
-            "displayName": "Openai Agents Sdk",
+            "displayName": "OpenAI Agents SDK",
             "description": "Minimal agent that streams text responses from a Foundry-backed model.",
             "path": "samples/python/hosted-agents/bring-your-own/responses/openai-agents-sdk",
             "requiresModel": true
@@ -284,7 +284,7 @@
             "language": "python",
             "framework": "bring-your-own",
             "protocol": "invocations",
-            "displayName": "Claude Agent Sdk",
+            "displayName": "Claude Agent SDK",
             "description": "Streams assistant responses for plain text queries with error handling.",
             "path": "samples/python/hosted-agents/bring-your-own/invocations/claude-agent-sdk",
             "requiresModel": false
@@ -347,7 +347,7 @@
             "language": "csharp",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Mcp Tools",
+            "displayName": "MCP Tools",
             "description": "Agent answers questions by searching documentation using integrated tool providers.",
             "path": "samples/csharp/hosted-agents/agent-framework/mcp-tools",
             "requiresModel": true
@@ -401,7 +401,7 @@
             "language": "csharp",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Text Search Rag",
+            "displayName": "Text Search RAG",
             "description": "Support agent that answers questions using external knowledge from support documents.",
             "path": "samples/csharp/hosted-agents/agent-framework/text-search-rag",
             "requiresModel": true
@@ -410,7 +410,7 @@
             "language": "csharp",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Azure Search Rag",
+            "displayName": "Azure Search RAG",
             "description": "Support agent answers questions using a keyword-indexed knowledge base for grounding.",
             "path": "samples/csharp/hosted-agents/agent-framework/azure-search-rag",
             "requiresModel": true
@@ -419,7 +419,7 @@
             "language": "csharp",
             "framework": "agent-framework",
             "protocol": "responses",
-            "displayName": "Foundry Memory Rag",
+            "displayName": "Foundry Memory RAG",
             "description": "Personal coach agent that remembers user preferences and goals across sessions.",
             "path": "samples/csharp/hosted-agents/agent-framework/foundry-memory-rag",
             "requiresModel": true

--- a/samples/hosted-agent/sample-overrides.json
+++ b/samples/hosted-agent/sample-overrides.json
@@ -1,7 +1,8 @@
 {
     "byPath": {
         "samples/python/hosted-agents/bring-your-own/invocations/github-copilot": {
-            "framework": "copilot-sdk"
+            "framework": "copilot-sdk",
+            "requiresModel": false
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #621. Polishes the `generate_sample_catalog.mjs` script and the `sync-sample-catalog.yml` workflow so the catalog regenerates correctly for nested sample layouts, fails loudly when anomalies appear, and produces stable display fields. The included regenerated `samples/hosted-agent/sample-catalog.json` is the output of running the workflow against `microsoft-foundry/foundry-samples@6ef684d`.

## What changed

### Script (`.github/scripts/generate_sample_catalog.mjs`)
- **Recursive tree walk.** Switched from per-directory `/contents/` calls (which capped at two nesting levels and silently missed `bring-your-own/voicelive/*`) to a single `git/trees?recursive=1` call. Outermost-template detection picks the right node when samples are themselves nested under category folders.
- **Deterministic `displayName`.** Always derived from the template's folder name (strips leading `NN-` ordering prefix, Title-Cases the rest). The LLM is now only consulted for `description`, which cuts token usage and removes a class of "invented words" feedback we kept hitting in review.
- **`requiresModel` from manifest.** When `agent.yaml` doesn't declare `AZURE_AI_MODEL_DEPLOYMENT_NAME`, fall back to scanning `agent.manifest.yaml` for a `kind: model` resource. Catches samples that wire the model through the manifest rather than env vars.
- **Stable dimension ordering.** Framework/language option order is now pinned to the insertion order of `DIMENSION_DEFAULTS`. Copilot SDK is first.
- **Anomaly reporting.** A module-level `warnings[]` collector now writes a `## Sample Catalog Generation` block to `$GITHUB_STEP_SUMMARY` listing every template that's missing a description, has an ambiguous protocol, etc. — no more grepping raw logs.
- **PM-edit preservation.** `mergeExistingDisplayFields` still preserves human-edited `displayName` / `description` from the previous catalog when the file is present.

### Workflow (`.github/workflows/sync-sample-catalog.yml`)
- Appends the resulting draft-PR number and URL to `$GITHUB_STEP_SUMMARY` so reviewers don't have to scroll through the logs.
- Added a `concurrency:` group so re-triggering the workflow cancels the in-flight run instead of racing it for the same PR branch.
- PR body wording updated to reflect that `displayName` is now auto-derived.

### Regenerated catalog (`samples/hosted-agent/sample-catalog.json`)
- 49 templates (was 34) — the recursive walk picks up previously-missed nested samples (notably the voicelive bring-your-own template).
- `requiresModel` and `protocol` re-derived from each sample's `agent.yaml` / `agent.manifest.yaml`.
- Dimension ordering reflects the new `DIMENSION_DEFAULTS`.

## Validation
- Local dry-run against `microsoft-foundry/foundry-samples@6ef684d`: 49 templates discovered, 0 anomalies.
- Workflow run against the same SHA produced the catalog included in this PR (originally landed via the auto-generated sub-PR #642, which was merged into this branch).
- `node --check` clean; `// @ts-check` JSDoc passes.

## Reviewer checks
- Confirm `language`, `framework`, `protocol`, and `requiresModel` look right on any unfamiliar templates in `sample-catalog.json`.
- Spot-check a few auto-generated descriptions for tone.
- Confirm no PM-edited display fields were accidentally lost (compare against the catalog on `dev`).
